### PR TITLE
fix: docker image data substitution

### DIFF
--- a/node-16/entrypoint.sh
+++ b/node-16/entrypoint.sh
@@ -56,12 +56,12 @@ if [[ $9 == 'true' ]]; then
   if [[ -z "${10}" ]]; then
     SLS_DEBUG=* serverless $4 --stage $1 --aws-profile $2
   else
-    SLS_DEBUG=* serverless $4 --stage $1 --aws-profile $2 --data "${10@Q}"
+    SLS_DEBUG=* serverless $4 --stage $1 --aws-profile $2 --data $10
   fi
 else
   if [[ -z "${10}" ]]; then
     serverless $4 --stage $1 --aws-profile $2
   else
-    serverless $4 --stage $1 --aws-profile $2 --data "${10@Q}"
+    serverless $4 --stage $1 --aws-profile $2 --data $10
   fi
 fi

--- a/node-16/entrypoint.sh
+++ b/node-16/entrypoint.sh
@@ -56,12 +56,12 @@ if [[ $9 == 'true' ]]; then
   if [[ -z "${10}" ]]; then
     SLS_DEBUG=* serverless $4 --stage $1 --aws-profile $2
   else
-    SLS_DEBUG=* serverless $4 --stage $1 --aws-profile $2 --data $10
+    SLS_DEBUG=* serverless $4 --stage $1 --aws-profile $2 --data ${10}
   fi
 else
   if [[ -z "${10}" ]]; then
     serverless $4 --stage $1 --aws-profile $2
   else
-    serverless $4 --stage $1 --aws-profile $2 --data $10
+    serverless $4 --stage $1 --aws-profile $2 --data ${10}
   fi
 fi


### PR DESCRIPTION
**Description:**
- fix serverless command data sent for situations when it has `data` arguments such as:

```
- name: Run database migrate
        uses: exporo/actions-serverless/node-16@v4
        with:
            command: invoke -f artisan
            data: '{"cli":"migrate"}'
            stage: ${{ env.STAGE }}
```

but the ones without data will not work (we'll need to get a solution for that cases (ewallet has them)
which  is based on "${10@Q}" previous version

```
- name: Run database migrate
        uses: exporo/actions-serverless/node-16@v4
        with:
            command: invoke -f artisan
            data: '{}'
            stage: ${{ env.STAGE }}
```